### PR TITLE
Add ensure unique notification interface

### DIFF
--- a/src/Contracts/EnsureUniqueNotification.php
+++ b/src/Contracts/EnsureUniqueNotification.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Okaufmann\LaravelNotificationLog\Contracts;
+
+use Okaufmann\LaravelNotificationLog\Database\NotificationHistoryQueryBuilder;
+
+interface EnsureUniqueNotification
+{
+    public function wasSentTo($notifiable, $withSameFingerprint = false): NotificationHistoryQueryBuilder;
+
+    public function fingerprint($notifiable): string;
+}

--- a/tests/Support/DummyNotificationWithHistory.php
+++ b/tests/Support/DummyNotificationWithHistory.php
@@ -5,11 +5,12 @@ namespace Okaufmann\LaravelNotificationLog\Tests\Support;
 use Closure;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
+use Okaufmann\LaravelNotificationLog\Contracts\EnsureUniqueNotification;
 use Okaufmann\LaravelNotificationLog\Contracts\ShouldLogNotification;
 use Okaufmann\LaravelNotificationLog\Models\Concerns\HasHistory;
 use Okaufmann\LaravelNotificationLog\Models\Concerns\LogsNotifications;
 
-class DummyNotificationWithHistory extends Notification implements ShouldLogNotification
+class DummyNotificationWithHistory extends Notification implements EnsureUniqueNotification, ShouldLogNotification
 {
     use HasHistory;
     use LogsNotifications;
@@ -29,7 +30,7 @@ class DummyNotificationWithHistory extends Notification implements ShouldLogNoti
         ]);
     }
 
-    public function fingerprint()
+    public function fingerprint($notifiable): string
     {
         return 'dummy-fingerprint';
     }


### PR DESCRIPTION
Adding the interface `Okaufmann\LaravelNotificationLog\Contracts\EnsureUniqueNotification` in combination with the `HasHistory` trait automatically checks whether or not a notification should be sent.